### PR TITLE
Fixed multiple shapes or texts copy from radial menu and light refactoring of copySelectedItems function

### DIFF
--- a/src/components/Workspace/Workspace.jsx
+++ b/src/components/Workspace/Workspace.jsx
@@ -52,7 +52,6 @@ import {
   renderSelectionRect } from './helpers/selection';
 
 import {
-  copySvgItem,
   computeSvgPath,
   dragItems,
   arePointsFeedable,
@@ -88,7 +87,6 @@ class Workspace extends Component {
 
     // svg
     this.deleteSvgItem = deleteSvgItem.bind(this);
-    this.copySvgItem = copySvgItem.bind(this);
     this.computeSvgPath = computeSvgPath.bind(this);
     this.arePointsFeedable = arePointsFeedable.bind(this);
     this.dragItems = dragItems.bind(this);

--- a/src/components/Workspace/helpers/svg.js
+++ b/src/components/Workspace/helpers/svg.js
@@ -1,48 +1,8 @@
 /* Node modules */
 import { has } from 'lodash';
 
-/* Helpers */
-import { cloneElement } from './copyPaste.js';
-
 /* Constants */
 import * as constants from '../../constants';
-
-
-/**
- * Copy the svg element and update its original position of selection
- * @param {string} uuid The id of the element to copy
- * @returns {string} The id of the newly copied element
- */
-export function copySvgItem(uuid) {
-  const { shapes, texts } = this.state;
-  let newUuid;
-
-  if (has(shapes, uuid)) {
-    const shape = shapes[uuid];
-    const newShape = cloneElement(uuid, shape, shapes);
-    newUuid = newShape.uuid;
-
-    this.setState({
-      shapes: {
-        ...shapes,
-        [newUuid]: newShape,
-      },
-    });
-  } else if (has(texts, uuid)) {
-    const text = texts[uuid];
-    const newText = cloneElement(uuid, text, texts);
-    newUuid = newText.uuid;
-
-    this.setState({
-      texts: {
-        ...texts,
-        [newUuid]: newText,
-      },
-    });
-  }
-
-  return newUuid;
-}
 
 
 /**


### PR DESCRIPTION
- Fixed bug of the issue #95 where it was impossible to copy multiple shapes or/and multiple texts from the radial menu.

- Light refactoring in copyPaste.js