### PR TITLE
use ref instead of onLoad pool

### DIFF
--- a/src/components/Workspace/helpers/selection.js
+++ b/src/components/Workspace/helpers/selection.js
@@ -13,9 +13,16 @@ export function getCentralPointOfSelection(selectedItems = this.state.selectedIt
   let top = 0;
   let bottom = Number.MAX_SAFE_INTEGER;
 
-  const svgPool = { ...this.svgShapes, ...this.svgTexts };
   for (const uuid of selectedItems) {
-    const box = svgPool[uuid].getBoundingClientRect();
+    const component = this.itemsList[uuid].getWrappedInstance();
+    let element;
+    // Check if component is Shape or Text
+    if (component.svgShape) {
+      element = component.svgShape;
+    } else {
+      element = component.svgText;
+    }
+    const box = element.getBoundingClientRect();
 
     right = Math.max(right, box.right);
     left = Math.min(left, box.left);


### PR DESCRIPTION
Fix ça: 
![pasted image at 2017_04_06 12_08 pm](https://cloud.githubusercontent.com/assets/11926403/24766178/554f76e6-1ac8-11e7-9bdf-f0772b49f672.png)

Dans le fond, le problème, c'est que les svgShapes sont updates `onLoad`, mais c'est pas called après la simulation lors d'un chagement de page pour une certaine raison (probablement du caching de Chrome ou whatev).
Donc j'utilise les ref que j,ai settupé précédemment. Elles sont fonctionnelles en tout temps et si vous acceptez ce PR, je vais pouvoir refactor pour qu'on utilise juste les refs au lieu du onLoad et et du svgPool.
