### PR TITLE
Fix textboxes by putting back refs, but they work now

### DIFF
--- a/src/components/Simulation/Control/Control.jsx
+++ b/src/components/Simulation/Control/Control.jsx
@@ -23,13 +23,8 @@ class Control extends Component {
     posX: PropTypes.number.isRequired,
     posY: PropTypes.number.isRequired,
     path: PropTypes.string.isRequired,
+    rect: PropTypes.object.isRequired,
   };
-
-  constructor(props, context) {
-    super(props, context);
-    this.padding = 10;
-  }
-
 
   componentWillMount() {
     this.extractControlData();
@@ -59,31 +54,23 @@ class Control extends Component {
     }
   }
 
-  onTexboxKeyPress(e) {
-    const textbox = e.currentTarget;
-    const letterSize = 13;
-    // Increment textbox size
-    textbox.style.width = `${this.padding * 2 + (textbox.value.length + 1) * letterSize}px`;
-  }
-
   getControl() {
     let control = null;
-    const { posX, posY } = this.props;
+    const { posX, posY, rect } = this.props;
 
     // the position where the control should be placed
+    const x = (Math.floor(rect.x + rect.width / 2.0) + posX) - rect.width / 2.0;
+    const y = (Math.floor(rect.y + rect.height / 2.0) + posY) - rect.height / 2.0;
     // Width and height need to be hardcoded, because without the ref, we can't get them
     // and the ref is never available on first render
-    const width = 200;
-    const height = 50;
-    const x = posX;
-    const y = posY;
+    const width = rect.width;
+    const height = rect.height;
 
     const controlStyle = {
       left: x,
       top: y,
       width,
       height,
-      padding: this.padding,
     };
 
     switch (this.shapeType) {
@@ -109,7 +96,6 @@ class Control extends Component {
               type="text"
               className="simulation-control simulation-textbox"
               style={controlStyle}
-              onKeyPress={(e) => this.onTexboxKeyPress(e)}
             />
           </foreignObject>
         );

--- a/src/components/Simulation/Simulation.jsx
+++ b/src/components/Simulation/Simulation.jsx
@@ -110,6 +110,7 @@ class Simulation extends Component {
         this.setState({
           shapes,
           texts,
+          refsLoaded: false,
         });
       }
     }

--- a/src/components/Simulation/Simulation.jsx
+++ b/src/components/Simulation/Simulation.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { filter, has, isEqual } from 'lodash';
+import { filter, has, isEqual, size } from 'lodash';
 
 /* Components */
 import Shape from '../Workspace/Shape/Shape';
@@ -46,6 +46,7 @@ class Simulation extends Component {
       pagesWithShapesFetched: [],
       pagesWithTextsFetched: [],
       modalId: '',
+      refsLoaded: false,
     };
   }
 
@@ -129,35 +130,34 @@ class Simulation extends Component {
     this.setState({ modalId: '' });
   }
 
+  shapeDidLoad() {
+    // All refs are needed to show controls, so we wait to have them all to set state
+    if (size(this.itemsList) >= size(this.state.shapes) && !this.state.refsLoaded) {
+      this.setState({ refsLoaded: true });
+    }
+  }
+
   renderShapes() {
     const { hiddenElements } = this.props.application.simulation;
-    let posX;
-    let posY;
 
     return (
       Object.entries(this.state.shapes)
             .filter(item => !hiddenElements.includes(item[0]))
-            .map((item, i) => {
-              if (this.isModal) {
-                posX = (item[1].x);
-                posY = (item[1].y);
-              } else {
-                posX = item[1].x;
-                posY = item[1].y;
-              }
-
-              return (
-                <Shape
-                  id={item[0]}
-                  ref={(shape) => { this.itemsList[item[0]] = shape; }}
-                  color={item[1].color}
-                  path={item[1].path}
-                  posX={posX}
-                  posY={posY}
-                  key={i}
-                />
-              );
-            })
+            .map((item, i) => (
+              <Shape
+                id={item[0]}
+                ref={(shape) => {
+                  this.itemsList[item[0]] = shape;
+                  this.shapeDidLoad();
+                }}
+                color={item[1].color}
+                path={item[1].path}
+                posX={item[1].x}
+                posY={item[1].y}
+                key={i}
+              />
+            )
+          )
     );
   }
 
@@ -185,19 +185,33 @@ class Simulation extends Component {
 
     return (
       // only show a control if its relative shape svg has been rendered
-      Object.entries(shapes).map((item) => (
-        <Control
-          id={`control-${item[0]}`}
-          controls={item[1].controls || {}}
-          shapeTypeId={item[1].shapeTypeId}
-          color={item[1].color}
-          posX={item[1].x}
-          posY={item[1].y}
-          path={item[1].path}
-          key={`control-${item[0]}`}
-          onClickModal={(pageId) => this.showModal(pageId)}
-        />
-      ))
+      Object.entries(shapes).map((item) => {
+        if (this.itemsList[item[0]]) {
+          const component = this.itemsList[item[0]].getWrappedInstance();
+          let element;
+          // Check if component is Shape or Text
+          if (component.svgShape) {
+            element = component.svgShape;
+          } else {
+            element = component.svgText;
+          }
+          return (
+            <Control
+              id={`control-${item[0]}`}
+              controls={item[1].controls || {}}
+              shapeTypeId={item[1].shapeTypeId}
+              color={item[1].color}
+              posX={item[1].x}
+              posY={item[1].y}
+              path={item[1].path}
+              key={`control-${item[0]}`}
+              rect={element.getBBox()}
+              onClickModal={(pageId) => this.showModal(pageId)}
+            />
+          );
+        }
+        return null;
+      })
     );
   }
 
@@ -264,7 +278,7 @@ class Simulation extends Component {
           </filter>
           {this.renderShapes()}
           {this.renderTexts()}
-          {this.renderControls()}
+          {this.state.refsLoaded && this.renderControls()}
         </svg>
       </div>
     );


### PR DESCRIPTION
To fix the bug Mr. McGuffin is expieriencing with textboxes, I had put back refs, so that way the textbox will always be exactly where the path is. 

to fix the bug where the refs didn,t load on time for controls, I added `shapeDidLoad()`, which is called everytime a ref is added and when ALL of them are there, I set `refsLoaded` to `true`, re-rendering and adding controls. This re-render is only called once and is fast enough for users to not even know the controls weren't there at first.